### PR TITLE
increase memcache defaults

### DIFF
--- a/configuration/components/memcached.libsonnet
+++ b/configuration/components/memcached.libsonnet
@@ -31,9 +31,9 @@ local defaults = {
   resources: {},
   serviceMonitor: false,
 
-  maxItemSize: '1m',
-  memoryLimitMb: 1024,
-  connectionLimit: 1024,
+  maxItemSize: '10m',
+  memoryLimitMb: 10240,
+  connectionLimit: 10240,
 
   cpuRequest:: '500m',
   cpuLimit:: '3',

--- a/configuration/components/thanos.libsonnet
+++ b/configuration/components/thanos.libsonnet
@@ -232,7 +232,7 @@ function(params) {
     objectStorageConfig: thanos.config.objectStorageConfig,
     replicas: 1,
     logLevel: 'info',
-    maxItemSize: '1MiB',
+    maxItemSize: '10MiB',
     local memcachedDefaults = {
       timeout: '2s',
       max_idle_connections: 1000,
@@ -294,7 +294,7 @@ function(params) {
     splitInterval: '24h',
     maxRetries: 0,
     logQueriesLongerThan: '5s',
-    maxItemSize: '1MiB',
+    maxItemSize: '10MiB',
     queryRangeCache: {
       type: 'memcached',
       config+: {


### PR DESCRIPTION
The current `memcache` defaults are too small for performance. The following values are found to be better for performance, especially larger deployments.

```
maxItemSize: '10m',
memoryLimitMb: 10240,
connectionLimit: 10240,
```