### PR TITLE
Add `--tsdb.too-far-in-future.time-window=5m` to default Receive args

### DIFF
--- a/configuration/components/observatorium.libsonnet
+++ b/configuration/components/observatorium.libsonnet
@@ -1,4 +1,5 @@
 local thanos = (import './thanos.libsonnet');
+local thanosOverwrites = (import './thanos-overwrites.libsonnet');
 local loki = (import './loki.libsonnet');
 local tracing = (import './tracing.libsonnet');
 local api = (import 'observatorium-api/observatorium-api.libsonnet');
@@ -27,7 +28,7 @@ local api = (import 'observatorium-api/observatorium-api.libsonnet');
     stores+: {
       shards: 1,
     },
-  }),
+  }) + thanosOverwrites,
 
   gubernator:: (import 'gubernator.libsonnet')({
     local cfg = self,

--- a/configuration/components/thanos-overwrites.libsonnet
+++ b/configuration/components/thanos-overwrites.libsonnet
@@ -1,0 +1,25 @@
+{
+  local thanos = self,
+  receivers+:: {
+    hashrings:
+      std.mapWithKey(function(hashring, obj) obj {  // loops over each [hashring]:obj
+        statefulSet+: {
+          spec+: {
+            template+: {
+              spec+: {
+                containers: [
+                  if c.name == 'thanos-receive' then c {
+                    args+: [
+                      '--tsdb.too-far-in-future.time-window=5m',
+                    ],
+                  }
+                  else c
+                  for c in super.containers
+                ],
+              },
+            },
+          },
+        },
+      }, super.hashrings),
+  },
+}

--- a/configuration/components/thanos.libsonnet
+++ b/configuration/components/thanos.libsonnet
@@ -21,6 +21,7 @@ local defaults = {
     tenants: [],
   }],
   stores+: {
+    maxItemSize: '10MiB',
     shards: 1,
     volumeClaimTemplate: {
       spec: {
@@ -127,6 +128,7 @@ local defaults = {
 
   queryFrontend: {
     replicas: 1,
+    maxItemSize: '10MiB',
   },
 
   queryFrontendCache: defaults.memcached {
@@ -232,7 +234,6 @@ function(params) {
     objectStorageConfig: thanos.config.objectStorageConfig,
     replicas: 1,
     logLevel: 'info',
-    maxItemSize: '10MiB',
     local memcachedDefaults = {
       timeout: '2s',
       max_idle_connections: 1000,
@@ -294,7 +295,6 @@ function(params) {
     splitInterval: '24h',
     maxRetries: 0,
     logQueriesLongerThan: '5s',
-    maxItemSize: '10MiB',
     queryRangeCache: {
       type: 'memcached',
       config+: {

--- a/configuration/examples/base/manifests/observatorium/thanos-query-frontend-cache-statefulSet.yaml
+++ b/configuration/examples/base/manifests/observatorium/thanos-query-frontend-cache-statefulSet.yaml
@@ -30,8 +30,8 @@ spec:
       containers:
       - args:
         - -m 1024
-        - -I 1m
-        - -c 1024
+        - -I 10m
+        - -c 10240
         - -v
         image: docker.io/memcached:1.6.3-alpine
         imagePullPolicy: IfNotPresent

--- a/configuration/examples/base/manifests/observatorium/thanos-query-frontend-deployment.yaml
+++ b/configuration/examples/base/manifests/observatorium/thanos-query-frontend-deployment.yaml
@@ -63,6 +63,7 @@ spec:
             "max_get_multi_batch_size": 0
             "max_get_multi_concurrency": 100
             "max_idle_connections": 100
+            "max_item_size": "10MiB"
             "timeout": "500ms"
           "type": "memcached"
         - |-
@@ -75,6 +76,7 @@ spec:
             "max_get_multi_batch_size": 0
             "max_get_multi_concurrency": 100
             "max_idle_connections": 100
+            "max_item_size": "10MiB"
             "timeout": "500ms"
           "type": "memcached"
         env:

--- a/configuration/examples/base/manifests/observatorium/thanos-store-cache-statefulSet.yaml
+++ b/configuration/examples/base/manifests/observatorium/thanos-store-cache-statefulSet.yaml
@@ -30,8 +30,8 @@ spec:
       containers:
       - args:
         - -m 1024
-        - -I 1m
-        - -c 1024
+        - -I 10m
+        - -c 10240
         - -v
         image: docker.io/memcached:1.6.3-alpine
         imagePullPolicy: IfNotPresent

--- a/configuration/examples/base/manifests/observatorium/thanos-store-shard0-statefulSet.yaml
+++ b/configuration/examples/base/manifests/observatorium/thanos-store-shard0-statefulSet.yaml
@@ -68,7 +68,7 @@ spec:
             "max_get_multi_batch_size": 1000
             "max_get_multi_concurrency": 900
             "max_idle_connections": 1000
-            "max_item_size": "1MiB"
+            "max_item_size": "10MiB"
             "timeout": "2s"
           "type": "memcached"
         - |-
@@ -85,7 +85,7 @@ spec:
             "max_get_multi_batch_size": 1000
             "max_get_multi_concurrency": 900
             "max_idle_connections": 1000
-            "max_item_size": "1MiB"
+            "max_item_size": "10MiB"
             "timeout": "2s"
           "max_chunks_get_range_requests": 3
           "metafile_content_ttl": "24h"

--- a/configuration/examples/dev/manifests/observatorium/thanos-query-frontend-cache-statefulSet.yaml
+++ b/configuration/examples/dev/manifests/observatorium/thanos-query-frontend-cache-statefulSet.yaml
@@ -30,8 +30,8 @@ spec:
       containers:
       - args:
         - -m 1024
-        - -I 1m
-        - -c 1024
+        - -I 10m
+        - -c 10240
         - -v
         image: docker.io/memcached:1.6.3-alpine
         imagePullPolicy: IfNotPresent

--- a/configuration/examples/dev/manifests/observatorium/thanos-query-frontend-deployment.yaml
+++ b/configuration/examples/dev/manifests/observatorium/thanos-query-frontend-deployment.yaml
@@ -63,6 +63,7 @@ spec:
             "max_get_multi_batch_size": 0
             "max_get_multi_concurrency": 100
             "max_idle_connections": 100
+            "max_item_size": "10MiB"
             "timeout": "500ms"
           "type": "memcached"
         - |-
@@ -75,6 +76,7 @@ spec:
             "max_get_multi_batch_size": 0
             "max_get_multi_concurrency": 100
             "max_idle_connections": 100
+            "max_item_size": "10MiB"
             "timeout": "500ms"
           "type": "memcached"
         env:

--- a/configuration/examples/dev/manifests/observatorium/thanos-store-cache-statefulSet.yaml
+++ b/configuration/examples/dev/manifests/observatorium/thanos-store-cache-statefulSet.yaml
@@ -30,8 +30,8 @@ spec:
       containers:
       - args:
         - -m 1024
-        - -I 1m
-        - -c 1024
+        - -I 10m
+        - -c 10240
         - -v
         image: docker.io/memcached:1.6.3-alpine
         imagePullPolicy: IfNotPresent

--- a/configuration/examples/dev/manifests/observatorium/thanos-store-shard0-statefulSet.yaml
+++ b/configuration/examples/dev/manifests/observatorium/thanos-store-shard0-statefulSet.yaml
@@ -68,7 +68,7 @@ spec:
             "max_get_multi_batch_size": 1000
             "max_get_multi_concurrency": 900
             "max_idle_connections": 1000
-            "max_item_size": "1MiB"
+            "max_item_size": "10MiB"
             "timeout": "2s"
           "type": "memcached"
         - |-
@@ -85,7 +85,7 @@ spec:
             "max_get_multi_batch_size": 1000
             "max_get_multi_concurrency": 900
             "max_idle_connections": 1000
-            "max_item_size": "1MiB"
+            "max_item_size": "10MiB"
             "timeout": "2s"
           "max_chunks_get_range_requests": 3
           "metafile_content_ttl": "24h"

--- a/configuration/examples/local/manifests/observatorium/thanos-query-frontend-cache-statefulSet.yaml
+++ b/configuration/examples/local/manifests/observatorium/thanos-query-frontend-cache-statefulSet.yaml
@@ -30,8 +30,8 @@ spec:
       containers:
       - args:
         - -m 1024
-        - -I 1m
-        - -c 1024
+        - -I 10m
+        - -c 10240
         - -v
         image: docker.io/memcached:1.6.3-alpine
         imagePullPolicy: IfNotPresent

--- a/configuration/examples/local/manifests/observatorium/thanos-query-frontend-deployment.yaml
+++ b/configuration/examples/local/manifests/observatorium/thanos-query-frontend-deployment.yaml
@@ -63,6 +63,7 @@ spec:
             "max_get_multi_batch_size": 0
             "max_get_multi_concurrency": 100
             "max_idle_connections": 100
+            "max_item_size": "10MiB"
             "timeout": "500ms"
           "type": "memcached"
         - |-
@@ -75,6 +76,7 @@ spec:
             "max_get_multi_batch_size": 0
             "max_get_multi_concurrency": 100
             "max_idle_connections": 100
+            "max_item_size": "10MiB"
             "timeout": "500ms"
           "type": "memcached"
         env:

--- a/configuration/examples/local/manifests/observatorium/thanos-store-cache-statefulSet.yaml
+++ b/configuration/examples/local/manifests/observatorium/thanos-store-cache-statefulSet.yaml
@@ -30,8 +30,8 @@ spec:
       containers:
       - args:
         - -m 1024
-        - -I 1m
-        - -c 1024
+        - -I 10m
+        - -c 10240
         - -v
         image: docker.io/memcached:1.6.3-alpine
         imagePullPolicy: IfNotPresent

--- a/configuration/examples/local/manifests/observatorium/thanos-store-shard0-statefulSet.yaml
+++ b/configuration/examples/local/manifests/observatorium/thanos-store-shard0-statefulSet.yaml
@@ -68,7 +68,7 @@ spec:
             "max_get_multi_batch_size": 1000
             "max_get_multi_concurrency": 900
             "max_idle_connections": 1000
-            "max_item_size": "1MiB"
+            "max_item_size": "10MiB"
             "timeout": "2s"
           "type": "memcached"
         - |-
@@ -85,7 +85,7 @@ spec:
             "max_get_multi_batch_size": 1000
             "max_get_multi_concurrency": 900
             "max_idle_connections": 1000
-            "max_item_size": "1MiB"
+            "max_item_size": "10MiB"
             "timeout": "2s"
           "max_chunks_get_range_requests": 3
           "metafile_content_ttl": "24h"


### PR DESCRIPTION
This should help prevent spokes with time-drift from bricking the metrics ingestion for everyone for too long.

Important note: the TSDB can still be advanced 5 minutes at a time, but any advance bigger than this will be ignored.

Note: had to fix this issue with the `maxItemSize` in memcache instances deployed for Store GW and Query Frontend to make the jsonnet templates compile.