### PR TITLE
Use Thanos promql engine by default

### DIFF
--- a/configuration/components/thanos-overwrites.libsonnet
+++ b/configuration/components/thanos-overwrites.libsonnet
@@ -22,4 +22,23 @@
         },
       }, super.hashrings),
   },
+  query+:: {
+    deployment+: {
+      spec+: {
+        template+: {
+          spec+: {
+            containers: [
+              if c.name == 'thanos-query' then c {
+                args+: [
+                  '--query.promql-engine=thanos',
+                ],
+              }
+              else c
+              for c in super.containers
+            ],
+          },
+        },
+      },
+    },
+  },
 }

--- a/configuration/examples/base/manifests/observatorium/thanos-query-deployment.yaml
+++ b/configuration/examples/base/manifests/observatorium/thanos-query-deployment.yaml
@@ -55,6 +55,7 @@ spec:
         - --store=dnssrv+_grpc._tcp.observatorium-xyz-thanos-receive-default.observatorium.svc.cluster.local
         - --query.timeout=15m
         - --query.auto-downsampling
+        - --query.promql-engine=thanos
         env:
         - name: HOST_IP_ADDRESS
           valueFrom:

--- a/configuration/examples/dev/manifests/observatorium/thanos-query-deployment.yaml
+++ b/configuration/examples/dev/manifests/observatorium/thanos-query-deployment.yaml
@@ -55,6 +55,7 @@ spec:
         - --store=dnssrv+_grpc._tcp.observatorium-xyz-thanos-receive-default.observatorium.svc.cluster.local
         - --query.timeout=15m
         - --query.auto-downsampling
+        - --query.promql-engine=thanos
         env:
         - name: HOST_IP_ADDRESS
           valueFrom:

--- a/configuration/examples/local/manifests/observatorium/thanos-query-deployment.yaml
+++ b/configuration/examples/local/manifests/observatorium/thanos-query-deployment.yaml
@@ -55,6 +55,7 @@ spec:
         - --store=dnssrv+_grpc._tcp.observatorium-xyz-thanos-receive-default.observatorium.svc.cluster.local
         - --query.timeout=15m
         - --query.auto-downsampling
+        - --query.promql-engine=thanos
         env:
         - name: HOST_IP_ADDRESS
           valueFrom:


### PR DESCRIPTION
We added an option for this in kube-thanos upstream, but need to update kube-thanos here for that, which can bring several unrelated changes. So adding an overwrite for that.