### PR TITLE
[ACM-14448] Set block discovery strategy to recursive for compact and store

### DIFF
--- a/configuration/components/thanos-overwrites.libsonnet
+++ b/configuration/components/thanos-overwrites.libsonnet
@@ -31,6 +31,7 @@
               if c.name == 'thanos-compact' then c {
                 args+: [
                   '--debug.max-compaction-level=3',
+                  '--block-discovery-strategy=recursive',
                 ],
               }
               else c
@@ -40,5 +41,26 @@
         },
       },
     },
+  },
+  stores+:: {
+    shards:
+      std.mapWithKey(function(shard, obj) obj {  // loops over each [shard-n]:obj
+        statefulSet+: {
+          spec+: {
+            template+: {
+              spec+: {
+                containers: [
+                  if c.name == 'thanos-store' then c {
+                    args+: [
+                      '--block-discovery-strategy="recursive"',
+                    ],
+                  } else c
+                  for c in super.containers
+                ],
+              },
+            },
+          },
+        },
+      }, super.shards),
   },
 }

--- a/configuration/examples/base/manifests/observatorium/thanos-compact-statefulSet.yaml
+++ b/configuration/examples/base/manifests/observatorium/thanos-compact-statefulSet.yaml
@@ -63,6 +63,7 @@ spec:
         - --downsampling.disable
         - --deduplication.replica-label=replica
         - --debug.max-compaction-level=3
+        - --block-discovery-strategy=recursive
         env:
         - name: OBJSTORE_CONFIG
           valueFrom:

--- a/configuration/examples/base/manifests/observatorium/thanos-query-deployment.yaml
+++ b/configuration/examples/base/manifests/observatorium/thanos-query-deployment.yaml
@@ -55,6 +55,7 @@ spec:
         - --endpoint=dnssrv+_grpc._tcp.observatorium-xyz-thanos-receive-default.observatorium.svc.cluster.local
         - --query.timeout=15m
         - --query.auto-downsampling
+        - --query.promql-engine=thanos
         env:
         - name: HOST_IP_ADDRESS
           valueFrom:

--- a/configuration/examples/base/manifests/observatorium/thanos-store-shard0-statefulSet.yaml
+++ b/configuration/examples/base/manifests/observatorium/thanos-store-shard0-statefulSet.yaml
@@ -102,6 +102,7 @@ spec:
             - action: keep
               source_labels: ["shard"]
               regex: 0
+        - --block-discovery-strategy="recursive"
         env:
         - name: OBJSTORE_CONFIG
           valueFrom:

--- a/configuration/examples/dev/manifests/observatorium/thanos-compact-statefulSet.yaml
+++ b/configuration/examples/dev/manifests/observatorium/thanos-compact-statefulSet.yaml
@@ -63,6 +63,7 @@ spec:
         - --downsampling.disable
         - --deduplication.replica-label=replica
         - --debug.max-compaction-level=3
+        - --block-discovery-strategy=recursive
         env:
         - name: OBJSTORE_CONFIG
           valueFrom:

--- a/configuration/examples/dev/manifests/observatorium/thanos-query-deployment.yaml
+++ b/configuration/examples/dev/manifests/observatorium/thanos-query-deployment.yaml
@@ -55,6 +55,7 @@ spec:
         - --endpoint=dnssrv+_grpc._tcp.observatorium-xyz-thanos-receive-default.observatorium.svc.cluster.local
         - --query.timeout=15m
         - --query.auto-downsampling
+        - --query.promql-engine=thanos
         env:
         - name: HOST_IP_ADDRESS
           valueFrom:

--- a/configuration/examples/dev/manifests/observatorium/thanos-store-shard0-statefulSet.yaml
+++ b/configuration/examples/dev/manifests/observatorium/thanos-store-shard0-statefulSet.yaml
@@ -102,6 +102,7 @@ spec:
             - action: keep
               source_labels: ["shard"]
               regex: 0
+        - --block-discovery-strategy="recursive"
         env:
         - name: OBJSTORE_CONFIG
           valueFrom:

--- a/configuration/examples/local/manifests/observatorium/thanos-compact-statefulSet.yaml
+++ b/configuration/examples/local/manifests/observatorium/thanos-compact-statefulSet.yaml
@@ -63,6 +63,7 @@ spec:
         - --downsampling.disable
         - --deduplication.replica-label=replica
         - --debug.max-compaction-level=3
+        - --block-discovery-strategy=recursive
         env:
         - name: OBJSTORE_CONFIG
           valueFrom:

--- a/configuration/examples/local/manifests/observatorium/thanos-query-deployment.yaml
+++ b/configuration/examples/local/manifests/observatorium/thanos-query-deployment.yaml
@@ -55,6 +55,7 @@ spec:
         - --endpoint=dnssrv+_grpc._tcp.observatorium-xyz-thanos-receive-default.observatorium.svc.cluster.local
         - --query.timeout=15m
         - --query.auto-downsampling
+        - --query.promql-engine=thanos
         env:
         - name: HOST_IP_ADDRESS
           valueFrom:

--- a/configuration/examples/local/manifests/observatorium/thanos-store-shard0-statefulSet.yaml
+++ b/configuration/examples/local/manifests/observatorium/thanos-store-shard0-statefulSet.yaml
@@ -102,6 +102,7 @@ spec:
             - action: keep
               source_labels: ["shard"]
               regex: 0
+        - --block-discovery-strategy="recursive"
         env:
         - name: OBJSTORE_CONFIG
           valueFrom:


### PR DESCRIPTION
Thanos 0.35 changed default block discovery strategy to `concurrent` which could increase object store traffic. 

Set this value back to `recursive`  using the new flag `--block-discovery-strategy=recursive` introduced in 0.35. This could help reduce the traffic at the expense of slow initialization of compact and store pods.