### PR TITLE
[ACM-26173] update thanos-receive-controller to pick up missing pod permissions 

### DIFF
--- a/configuration/examples/base/manifests/observatorium/thanos-receive-controller-deployment.yaml
+++ b/configuration/examples/base/manifests/observatorium/thanos-receive-controller-deployment.yaml
@@ -47,4 +47,4 @@ spec:
       securityContext:
         fsGroup: 65534
         runAsUser: 65534
-      serviceAccount: observatorium-xyz-thanos-receive-controller
+      serviceAccountName: observatorium-xyz-thanos-receive-controller

--- a/configuration/examples/base/manifests/observatorium/thanos-receive-controller-role.yaml
+++ b/configuration/examples/base/manifests/observatorium/thanos-receive-controller-role.yaml
@@ -20,6 +20,15 @@ rules:
   - get
   - create
   - update
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - list
+  - get
+  - update
 - apiGroups:
   - apps
   resources:

--- a/configuration/examples/dev/manifests/observatorium/thanos-receive-controller-deployment.yaml
+++ b/configuration/examples/dev/manifests/observatorium/thanos-receive-controller-deployment.yaml
@@ -47,4 +47,4 @@ spec:
       securityContext:
         fsGroup: 65534
         runAsUser: 65534
-      serviceAccount: observatorium-xyz-thanos-receive-controller
+      serviceAccountName: observatorium-xyz-thanos-receive-controller

--- a/configuration/examples/dev/manifests/observatorium/thanos-receive-controller-role.yaml
+++ b/configuration/examples/dev/manifests/observatorium/thanos-receive-controller-role.yaml
@@ -20,6 +20,15 @@ rules:
   - get
   - create
   - update
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - list
+  - get
+  - update
 - apiGroups:
   - apps
   resources:

--- a/configuration/examples/local/manifests/observatorium/thanos-receive-controller-deployment.yaml
+++ b/configuration/examples/local/manifests/observatorium/thanos-receive-controller-deployment.yaml
@@ -47,4 +47,4 @@ spec:
       securityContext:
         fsGroup: 65534
         runAsUser: 65534
-      serviceAccount: observatorium-xyz-thanos-receive-controller
+      serviceAccountName: observatorium-xyz-thanos-receive-controller

--- a/configuration/examples/local/manifests/observatorium/thanos-receive-controller-role.yaml
+++ b/configuration/examples/local/manifests/observatorium/thanos-receive-controller-role.yaml
@@ -20,6 +20,15 @@ rules:
   - get
   - create
   - update
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - list
+  - get
+  - update
 - apiGroups:
   - apps
   resources:

--- a/configuration/jsonnetfile.json
+++ b/configuration/jsonnetfile.json
@@ -14,11 +14,11 @@
     {
       "source": {
         "git": {
-          "remote": "https://github.com/observatorium/thanos-receive-controller.git",
+          "remote": "https://github.com/stolostron/thanos-receive-controller.git",
           "subdir": "jsonnet/lib"
         }
       },
-      "version": "master",
+      "version": "release-2.16",
       "name": "thanos-receive-controller"
     },
     {

--- a/configuration/jsonnetfile.lock.json
+++ b/configuration/jsonnetfile.lock.json
@@ -105,12 +105,12 @@
     {
       "source": {
         "git": {
-          "remote": "https://github.com/observatorium/thanos-receive-controller.git",
+          "remote": "https://github.com/stolostron/thanos-receive-controller.git",
           "subdir": "jsonnet/lib"
         }
       },
-      "version": "929e5752817548374c8a4f3cf0e3adadb3c0fc18",
-      "sum": "0yZzNAcHQER0vE90d4iur3mYSitIhe8DhIFBeWdlb6k=",
+      "version": "bb555b04d422814a6fa5861b961f3dcff2dce0f2",
+      "sum": "KG4fosMr9R2szMfkrIadwZts3OqHg7E4aQqzMdg+og8=",
       "name": "thanos-receive-controller"
     },
     {


### PR DESCRIPTION
The receive controller role is missing pod permissions which is preventing it from doing hashring update.
```
- apiGroups:
  - ""
  resources:
  - pods
  verbs:
  - list
  - get
  - update
 ```
