### PR TITLE
[ACM-27042] Remove compaction level limitation on thanos compactor

### DIFF
--- a/configuration/components/thanos-overwrites.libsonnet
+++ b/configuration/components/thanos-overwrites.libsonnet
@@ -30,7 +30,6 @@
             containers: [
               if c.name == 'thanos-compact' then c {
                 args+: [
-                  '--debug.max-compaction-level=3',
                   '--block-discovery-strategy=recursive',
                 ],
               }

--- a/configuration/examples/base/manifests/observatorium/thanos-compact-statefulSet.yaml
+++ b/configuration/examples/base/manifests/observatorium/thanos-compact-statefulSet.yaml
@@ -62,7 +62,6 @@ spec:
         - --downsample.concurrency=4
         - --downsampling.disable
         - --deduplication.replica-label=replica
-        - --debug.max-compaction-level=3
         - --block-discovery-strategy=recursive
         env:
         - name: OBJSTORE_CONFIG

--- a/configuration/examples/dev/manifests/observatorium/thanos-compact-statefulSet.yaml
+++ b/configuration/examples/dev/manifests/observatorium/thanos-compact-statefulSet.yaml
@@ -62,7 +62,6 @@ spec:
         - --downsample.concurrency=4
         - --downsampling.disable
         - --deduplication.replica-label=replica
-        - --debug.max-compaction-level=3
         - --block-discovery-strategy=recursive
         env:
         - name: OBJSTORE_CONFIG

--- a/configuration/examples/local/manifests/observatorium/thanos-compact-statefulSet.yaml
+++ b/configuration/examples/local/manifests/observatorium/thanos-compact-statefulSet.yaml
@@ -62,7 +62,6 @@ spec:
         - --downsample.concurrency=4
         - --downsampling.disable
         - --deduplication.replica-label=replica
-        - --debug.max-compaction-level=3
         - --block-discovery-strategy=recursive
         env:
         - name: OBJSTORE_CONFIG


### PR DESCRIPTION
Removing the '--debug.max-compaction-level=3' flag will set the max-compaction-level to the default of 4. This is necessary as thanos can only downsample to 1 hr resolution if a block of 10d+ is created, and a max compaction level of 3 creates blocks of only 2 days.

The block-max-index-size should remain as the default 64 GB as there is a constraint in thanos that prevents writing index files larger than 64 GB https://github.com/thanos-io/thanos/blob/9e0fc138f157f3055dc3f0bbf33fd1e94ef36f8d/pkg/block/indexheader/binary_reader.go#L432-L445

### Example using synthetic data
With Thanos max compaction level set to 4 downsamples to 1h resolution
<img width="1919" height="899" alt="thanos-compact-lvl-4-pull" src="https://github.com/user-attachments/assets/ebcb2e9a-1009-4fd3-a50b-ecb2fbe310a8" />


 With Thanos max compaction level set to 3 fails to downsample to 1h resolution
<img width="1919" height="898" alt="compact-lvl-3-downsample-pull" src="https://github.com/user-attachments/assets/74ff6ade-ff71-4e76-b59b-1e7816a2574c" />

